### PR TITLE
Add support for legacy format of deck link (/deck.php?id=__)

### DIFF
--- a/Controllers/Deck.php
+++ b/Controllers/Deck.php
@@ -15,6 +15,11 @@ class Deck extends Controller
     public function process(array $args = []): int
     {
         $packageId = array_shift($args) ?? null;
+
+        if (!is_numeric($packageId) && $packageId === 'legacy') {
+            $packageId = $_GET['id'];
+        }
+
         if (!empty($args)) {
             self::$data['deck']['uploadAction'] = array_shift($args);
         }

--- a/routes.ini
+++ b/routes.ini
@@ -5,6 +5,7 @@
 /=Index
 /browse=Browse
 /deck/<0>=Deck?<0>
+/deck.php=Deck?legacy
 /deck/<0>/download=DeckDownload?<0>
 /my-decks=Manage
 /new-deck=Create


### PR DESCRIPTION
This way, all the old links that were already shared over the internet will continue to work.