### PR TITLE
Fix invalid URL format for private decks

### DIFF
--- a/Controllers/Deck.php
+++ b/Controllers/Deck.php
@@ -54,7 +54,7 @@ class Deck extends Controller
             $this->redirect($package->getDetailsLink());
         }
 
-        $queryString = "/$packageId/<span style=\"color: gold;\">".$package->getVersion()."</span>".(empty($accessKey) ? '' : "&amp;key=$accessKey");
+        $queryString = "/$packageId/<span style=\"color: gold;\">".$package->getVersion()."</span>".(empty($accessKey) ? '' : "?key=$accessKey");
 
         self::$data['layout']['page_id'] = 'deck-info';
         self::$data['layout']['Title'] = $package->getName();
@@ -63,7 +63,7 @@ class Deck extends Controller
         self::$data['deck']['packageId'] = $packageId;
         self::$data['deck']['accessKey'] = $accessKey;
         self::$data['deck']['queryString'] = $queryString;
-        self::$data['deck']['shareLink'] = (!empty($_SERVER['HTTPS']) ? 'https://' : 'http://').$_SERVER['SERVER_NAME'].'/deck/'.$packageId.(empty($accessKey) ? '' : "&amp;key=$accessKey");
+        self::$data['deck']['shareLink'] = (!empty($_SERVER['HTTPS']) ? 'https://' : 'http://').$_SERVER['SERVER_NAME'].'/deck/'.$packageId.(empty($accessKey) ? '' : "?key=$accessKey");
         self::$data['deck']['detailsLink'] = $package->getDetailsLink();
         self::$data['deck']['downloadLink'] = $package->getDownloadLink();
         self::$data['deck']['hostedLocally'] = $package->isHostedLocally();


### PR DESCRIPTION
URLs were in the form of /deck/1&key=... instead of /deck/1?key=... This is a result of removing deck ID as the first URL argument (that was bringing the "?" sign) some time ago.